### PR TITLE
Fix Synapse DB name

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -2,6 +2,16 @@
 
 APP_BIN=mautrix-discord
 
+#=================================================
+# PERSONAL HELPERS
+#=================================================
+
+get_synapse_db_name() {
+	# Parameters: synapse instance identifier
+	# Returns: database name
+	ynh_app_setting_get --app="$1" --key=db_name
+}
+
 apply_permissions() {
     set -o noglob # Disable globbing to avoid expansions when passing * as value.
     declare values="list$role"

--- a/scripts/install
+++ b/scripts/install
@@ -14,7 +14,7 @@ server_name=$(ynh_app_setting_get --app $synapse_instance --key server_name)
 domain=$(ynh_app_setting_get --app $synapse_instance --key domain)
 ynh_app_setting_set --app=$app --key=server_name --value=$server_name
 ynh_app_setting_set --app=$app --key=domain --value=$domain
-synapse_db_name="matrix_$synapse_instance"
+synapse_db_name="$(get_synapse_db_name $synapse_instance)"
 
 synapse_version=$(yunohost app info $synapse_instance | grep -oP "version:\s*\K.*")
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -12,7 +12,7 @@ source /usr/share/yunohost/helpers
 
 server_name=$(ynh_app_setting_get --app=$app --key=server_name)
 
-synapse_db_name="matrix_$synapse_instance"
+synapse_db_name="$(get_synapse_db_name $synapse_instance)"
 bot_synapse_db_user="@$botname:$server_name"
 
 async_media=$(ynh_app_setting_get --app=$app --key=async_media)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -11,7 +11,7 @@ source /usr/share/yunohost/helpers
 
 server_name=$(ynh_app_setting_get --app=$app --key=server_name)
 
-synapse_db_name="matrix_$synapse_instance"
+synapse_db_name="$(get_synapse_db_name $synapse_instance)"
 bot_synapse_db_user="@$botname:$server_name"
 appserviceid=$app
 


### PR DESCRIPTION
## Problem

Synapse DB was renamed from `matrix_$app` to `$app`. See https://github.com/YunoHost-Apps/synapse_ynh/blob/master/scripts/upgrade#L194 . Still, the scripts here (install, upgrade, restore) use `matrix_$app` as DB name.

## Solution

Added a helper function for retrieving the actual DB name for the synapse app, as I did for `mautrix_whatsapp_ynh`. See https://github.com/YunoHost-Apps/mautrix_whatsapp_ynh/pull/145

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
